### PR TITLE
Fix some minor typos and reference to "develop" branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to Survey Data Collection repositories
 ===================================================
 
-* We use github-flow - create a branch from master with a short, concise, name, e.g. (nb. there are no specific prefixes):
+* We use [github-flow](http://scottchacon.com/2011/08/31/github-flow.html) - create a branch from master with a short, concise, name, e.g. (nb. there are no specific prefixes):
     * add-user-auth
     * fix-ioloop-bug
     * update-cryptography-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 Contributing to Survey Data Collection repositories
 ===================================================
 
-* We use git-flow - create a feature branch from develop, e.g. feature/new-feature
+* We use github-flow - create a branch from master, e.g.:
+    * feature/new-feature
+    * fix/some-bug
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
 * Ensure your branch contains logical atomic commits before sending a pull request - follow the [alphagov Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 * You may rebase your branch after feedback if it's to include relevant updates from the develop branch. We prefer a rebase here to a merge commit as we

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 Contributing to Survey Data Collection repositories
 ===================================================
 
-* We use github-flow - create a branch from master, e.g.:
-    * feature/new-feature
-    * fix/some-bug
+* We use github-flow - create a branch from master with a short, concise, name, e.g. (nb. there are no specific prefixes):
+    * add-user-auth
+    * fix-ioloop-bug
+    * update-cryptography-version
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
 * Ensure your branch contains logical atomic commits before sending a pull request - follow the [alphagov Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 * You may rebase your branch after feedback if it's to include relevant updates from the develop branch. We prefer a rebase here to a merge commit as we

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,5 +7,5 @@ Contributing to Survey Data Collection repositories
     * update-cryptography-version
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
 * Ensure your branch contains logical atomic commits before sending a pull request - follow the [alphagov Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
-* You may rebase your branch after feedback if it's to include relevant updates from the develop branch. We prefer a rebase here to a merge commit as we
-prefer a clean and straight history on develop with discrete merge commits for features
+* You may rebase your branch after feedback if it's to include relevant updates from the master branch. We prefer a rebase here to a merge commit as we
+prefer a clean and straight history on master with discrete merge commits for features

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ business systems.
   - [Contributing](CONTRIBUTING.md)
 
 
-## Licence
+## License
 
 Copyright ©‎ 2017, Crown Copyright (Office for National Statistics)
 


### PR DESCRIPTION
- Fix spelling of "license" in readme
- Remove reference to "develop" branch in contributing